### PR TITLE
feat: add FrankenPHP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,36 +3,66 @@
 [![last commit](https://img.shields.io/github/last-commit/stasadev/ddev-frankenphp)](https://github.com/stasadev/ddev-frankenphp/commits)
 [![release](https://img.shields.io/github/v/release/stasadev/ddev-frankenphp)](https://github.com/stasadev/ddev-frankenphp/releases/latest)
 
-# DDEV Frankenphp
+# DDEV FrankenPHP
 
 ## Overview
 
-This add-on integrates Frankenphp into your [DDEV](https://ddev.com/) project.
+[FrankenPHP](https://frankenphp.dev/) is a modern application server for PHP built on top of the [Caddy](https://caddyserver.com/) web server.
+
+This add-on integrates FrankenPHP into your [DDEV](https://ddev.com/) project.
 
 ## Installation
 
 ```bash
+ddev config --webserver-type=generic
 ddev add-on get stasadev/ddev-frankenphp
 ddev restart
 ```
 
 After installation, make sure to commit the `.ddev` directory to version control.
 
+### Using a different docroot
+
+To change the `docroot` from the default `public` directory to something else, remove the `#ddev-generated` line from the`.ddev/frankenphp/Caddyfile` and update the `root public/` line.
+
 ## Usage
 
 | Command | Description |
 | ------- | ----------- |
-| `ddev describe` | View service status and used ports for Frankenphp |
-| `ddev logs -s frankenphp` | Check Frankenphp logs |
+| `ddev describe` | View service status and ports used by FrankenPHP |
+| `ddev php` | Run PHP in the FrankenPHP container |
+| `ddev exec -s frankenphp -- bash` | Enter the FrankenPHP container |
+| `ddev logs -s frankenphp -f` | View FrankenPHP logs |
+
+## Caveats
+
+- To make Xdebug available on the host, create a `.ddev/docker-compose.frankenphp_extra.yaml` file, and replace `IP_ADDRESS` with the IP from `ddev exec ping -c1 host.docker.internal`. If you're on Linux, use `host-gateway` instead of `IP_ADDRESS`:
+    ```yaml
+    services:
+      frankenphp:
+        extra_hosts:
+          - "host.docker.internal:IP_ADDRESS"
+    ```
+- `ddev launch` doesn't work. Open the website URL directly in your browser.
 
 ## Advanced Customization
 
 To change the Docker image:
 
 ```bash
-ddev dotenv set .ddev/.env.frankenphp --frankenphp-docker-image="busybox:stable"
+ddev dotenv set .ddev/.env.frankenphp --frankenphp-docker-image="dunglas/frankenphp:php8.3"
 ddev add-on get stasadev/ddev-frankenphp
-ddev restart
+ddev stop && ddev debug rebuild -s frankenphp && ddev start
+```
+
+Make sure to commit the `.ddev/.env.frankenphp` file to version control.
+
+To add PHP extensions:
+
+```bash
+ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="opcache xdebug"
+ddev add-on get stasadev/ddev-frankenphp
+ddev stop && ddev debug rebuild -s frankenphp && ddev start
 ```
 
 Make sure to commit the `.ddev/.env.frankenphp` file to version control.
@@ -41,7 +71,12 @@ All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
-| `FRANKENPHP_DOCKER_IMAGE` | `--frankenphp-docker-image` | `busybox:stable` |
+| `FRANKENPHP_DOCKER_IMAGE` | `--frankenphp-docker-image` | `dunglas/frankenphp:php8.3` |
+| `FRANKENPHP_PHP_EXTENSIONS` | `--frankenphp-php-extensions` | `opcache xdebug` |
+
+## Resources:
+
+- [FrankenPHP Documentation](https://frankenphp.dev/docs/)
 
 ## Credits
 

--- a/commands/frankenphp/php
+++ b/commands/frankenphp/php
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Run php inside the frankenphp container
+## Usage: php [flags] [args]
+## Example: "ddev php --version"
+## ExecRaw: true
+## MutagenSync: true
+
+php "$@"

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -1,16 +1,43 @@
 #ddev-generated
-# Simple template to demonstrate frankenphp
 services:
   frankenphp:
     container_name: ddev-${DDEV_SITENAME}-frankenphp
-    image: ${FRANKENPHP_DOCKER_IMAGE:-busybox:stable}
-    command: tail -f /dev/null
-    restart: "no"
-    # These labels ensure this service is discoverable by DDEV.
+    build:
+      dockerfile_inline: |
+        ARG FRANKENPHP_DOCKER_IMAGE=scratch
+        FROM $${FRANKENPHP_DOCKER_IMAGE}
+        ARG FRANKENPHP_PHP_EXTENSIONS=""
+        RUN [ -z "$${FRANKENPHP_PHP_EXTENSIONS}" ] || install-php-extensions $${FRANKENPHP_PHP_EXTENSIONS}
+        ARG FRANKENPHP_USER=ddev
+        ARG DDEV_UID
+        ARG DDEV_GID
+        RUN <<EOF
+          set -eu
+          groupadd -g $${DDEV_GID} $${FRANKENPHP_USER}
+          useradd -u $${DDEV_UID} -g $${DDEV_GID} $${FRANKENPHP_USER}
+          setcap -r /usr/local/bin/frankenphp
+          chown -R $${FRANKENPHP_USER}:$${FRANKENPHP_USER} /data/caddy /config/caddy
+        EOF
+        USER $${FRANKENPHP_USER}
+      args:
+        FRANKENPHP_DOCKER_IMAGE: ${FRANKENPHP_DOCKER_IMAGE:-dunglas/frankenphp:php8.3}
+        FRANKENPHP_PHP_EXTENSIONS: ${FRANKENPHP_PHP_EXTENSIONS:-opcache xdebug}
+        DDEV_UID: ${DDEV_UID}
+        DDEV_GID: ${DDEV_GID}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
-
+    environment:
+      - SERVER_NAME=:8000
+      - VIRTUAL_HOST=${DDEV_HOSTNAME}
+      - HTTP_EXPOSE=80:8000
+      - HTTPS_EXPOSE=443:8000
     volumes:
+      - "../:/app"
+      - "./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile"
+      - "./php/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
+    # Two lines below are for Xdebug on Linux, see README.md for details
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway"

--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -1,0 +1,63 @@
+#ddev-generated
+# This is a copy of the upstream Caddyfile.
+# https://github.com/php/frankenphp/blob/main/caddy/frankenphp/Caddyfile
+#
+# The Caddyfile is an easy way to configure FrankenPHP and the Caddy web server.
+#
+# https://frankenphp.dev/docs/config
+# https://caddyserver.com/docs/caddyfile
+
+{
+	skip_install_trust
+
+	{$CADDY_GLOBAL_OPTIONS}
+
+	frankenphp {
+		{$FRANKENPHP_CONFIG}
+	}
+}
+
+{$CADDY_EXTRA_CONFIG}
+
+{$SERVER_NAME:localhost} {
+	#log {
+	#	# Redact the authorization query parameter that can be set by Mercure
+	#	format filter {
+	#		request>uri query {
+	#			replace authorization REDACTED
+	#		}
+	#	}
+	#}
+
+	root public/
+	encode zstd br gzip
+
+	# Uncomment the following lines to enable Mercure and Vulcain modules
+	#mercure {
+	#	# Transport to use (default to Bolt)
+	#	transport_url {$MERCURE_TRANSPORT_URL:bolt:///data/mercure.db}
+	#	# Publisher JWT key
+	#	publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
+	#	# Subscriber JWT key
+	#	subscriber_jwt {env.MERCURE_SUBSCRIBER_JWT_KEY} {env.MERCURE_SUBSCRIBER_JWT_ALG}
+	#	# Allow anonymous subscribers (double-check that it's what you want)
+	#	anonymous
+	#	# Enable the subscription API (double-check that it's what you want)
+	#	subscriptions
+	#	# Extra directives
+	#	{$MERCURE_EXTRA_DIRECTIVES}
+	#}
+	#vulcain
+
+	{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+	php_server {
+		#worker /path/to/your/worker.php
+	}
+}
+
+# As an alternative to editing the above site block, you can add your own site
+# block files in the Caddyfile.d directory, and they will be included as long
+# as they use the .caddyfile extension.
+
+import Caddyfile.d/*.caddyfile

--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,18 @@
 name: frankenphp
 
 project_files:
+  - commands/frankenphp/php
   - docker-compose.frankenphp.yaml
+  - frankenphp/Caddyfile
+  - php/docker-php-ext-xdebug.ini
+
+pre_install_actions:
+  - |
+    #ddev-description:Check for generic webserver type
+    {{ if ne .DdevProjectConfig.webserver_type "generic" }}
+    echo "The add-on only works with the 'generic' webserver type."
+    echo "Run 'ddev config --webserver-type=generic' and repeat this command again."
+    exit 1
+    {{ end }}
 
 ddev_version_constraint: '>= v1.24.3'

--- a/php/docker-php-ext-xdebug.ini
+++ b/php/docker-php-ext-xdebug.ini
@@ -1,0 +1,8 @@
+#ddev-generated
+zend_extension=xdebug.so
+xdebug.client_host=host.docker.internal
+xdebug.discover_client_host=1
+xdebug.client_port=9003
+xdebug.mode=debug,develop
+xdebug.start_with_request=yes
+xdebug.max_nesting_level=1000


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/issues/7360

We want to have a way to use FrankenPHP the way it's meant to be used.

Currently, we install it from a static binary https://ddev.readthedocs.io/en/stable/users/quickstart/#generic-frankenphp

## How This PR Solves The Issue

Uses the official Docker image to run FrankenPHP.

## Manual Testing Instructions

Review https://github.com/stasadev/ddev-frankenphp/blob/20250609_stasadev_frankenphp/README.md

```bash
ddev config --webserver-type=generic
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/1/head
ddev restart
ddev php -v
```

And add more PHP extensions:

```bash
ddev config --webserver-type=generic
ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="redis opcache xdebug"
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/1/head
ddev stop && ddev debug rebuild -s frankenphp && ddev start
ddev php -m
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
