### PR TITLE
Add xdebug vscode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,6 @@ To change the `docroot` from the default `public` directory to something else, r
         extra_hosts:
           - "host.docker.internal:IP_ADDRESS"
     ```
-If using VS Code, create a launch.json config such as this (`/app/public`, is the path within the Frankenphp Docker container where the app files go - as opposed to `/var/www/html` in the DDEV web container).
-
-```json
-{
-    "name": "Listen for Xdebug",
-    "type": "php",
-    "request": "launch",
-    "port": 9003,
-    "pathMappings": {
-        "/app/public": "${workspaceFolder}/public"
-    }
-},
-```
-
 - `ddev xdebug` is only designed to work in the `web` container, it won't work here.
 - `ddev launch` doesn't work. Open the website URL directly in your browser.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To change the `docroot` from the default `public` directory to something else, r
 
 ## Caveats
 
-- To make Xdebug available on the host, create a `.ddev/docker-compose.frankenphp_extra.yaml` file, and replace `IP_ADDRESS` with the IP from `ddev exec ping -c1 host.docker.internal`. If you're on Linux, use `host-gateway` instead of `IP_ADDRESS`:
+- To make Xdebug available on the host, create a `.ddev/docker-compose.frankenphp_extra.yaml` file, and replace `IP_ADDRESS` with the IP from `ddev exec ping -c1 host.docker.internal`. If you're on Linux (including WSL2), use `host-gateway` instead of `IP_ADDRESS`:
     ```yaml
     services:
       frankenphp:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To change the `docroot` from the default `public` directory to something else, r
         extra_hosts:
           - "host.docker.internal:IP_ADDRESS"
     ```
-If using VS Code, create a launch.json config such as this (`/app/public`, is the path within the Frankenphp Docker container where the app files go - as opposed to `/var/www/html` in the ddev web container).
+If using VS Code, create a launch.json config such as this (`/app/public`, is the path within the Frankenphp Docker container where the app files go - as opposed to `/var/www/html` in the DDEV web container).
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ To change the `docroot` from the default `public` directory to something else, r
         extra_hosts:
           - "host.docker.internal:IP_ADDRESS"
     ```
+If using VS Code, create a launch.json config such as this (`/app/public`, is the path within the Frankenphp Docker container where the app files go - as opposed to `/var/www/html` in the ddev web container).
+
+```json
+{
+    "name": "Listen for Xdebug",
+    "type": "php",
+    "request": "launch",
+    "port": 9003,
+    "pathMappings": {
+        "/app/public": "${workspaceFolder}/public"
+    }
+},
+```
+
 - `ddev xdebug` is only designed to work in the `web` container, it won't work here.
 - `ddev launch` doesn't work. Open the website URL directly in your browser.
 

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -32,8 +32,9 @@ services:
       - VIRTUAL_HOST=${DDEV_HOSTNAME}
       - HTTP_EXPOSE=80:8000
       - HTTPS_EXPOSE=443:8000
+    working_dir: /var/www/html
     volumes:
-      - "../:/app"
+      - "../:/var/www/html"
       - "./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile"
       - "./php/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
       - ".:/mnt/ddev_config"


### PR DESCRIPTION
## The Issue

VS Code configs for DDEV don't work here https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/#visual-studio-code-vs-code-debugging-setup

## How This PR Solves The Issue

Uses the default `/var/www/html` project location inside the container.

This makes things easier for Xdebug.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/5/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
