### PR TITLE
fix: use a readable hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To change the `docroot` from the default `public` directory to something else, r
 | ------- | ----------- |
 | `ddev describe` | View service status and ports used by FrankenPHP |
 | `ddev php` | Run PHP in the FrankenPHP container |
-| `ddev exec -s frankenphp -- bash` | Enter the FrankenPHP container |
+| `ddev exec -s frankenphp bash` | Enter the FrankenPHP container |
 | `ddev logs -s frankenphp -f` | View FrankenPHP logs |
 
 ## Caveats

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -2,6 +2,7 @@
 services:
   frankenphp:
     container_name: ddev-${DDEV_SITENAME}-frankenphp
+    hostname: ${DDEV_SITENAME}-frankenphp
     build:
       dockerfile_inline: |
         ARG FRANKENPHP_DOCKER_IMAGE=scratch


### PR DESCRIPTION
## The Issue

`20f66ed5f4ce` here:

```
$ ddev exec -s frankenphp bash   
ddev@20f66ed5f4ce:/var/www/html$ 
```

But `d11-web` here:
```
$ ddev ssh
stas@d11-web:/var/www/html$ 
`
```

## How This PR Solves The Issue

Adds the hostname in a similar way to the `web` container.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/8/head
ddev restart
ddev exec -s frankenphp bash   
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
