### PR TITLE
feat: automatic docroot in Caddy, fixes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ ddev restart
 
 After installation, make sure to commit the `.ddev` directory to version control.
 
-### Using a different docroot
-
-To change the `docroot` from the default `public` directory to something else, remove the `#ddev-generated` line from the`.ddev/frankenphp/Caddyfile` and update the `root public/` line.
-
 ## Usage
 
 | Command | Description |

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -29,15 +29,15 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
     environment:
-      - SERVER_NAME=:8000
       - PHP_INI_SCAN_DIR=:/usr/local/etc/php/ddev.conf.d
+      - DDEV_DOCROOT=${DDEV_DOCROOT:-.}
       - VIRTUAL_HOST=${DDEV_HOSTNAME}
       - HTTP_EXPOSE=80:8000
       - HTTPS_EXPOSE=443:8000
     working_dir: /var/www/html
     volumes:
       - "../:/var/www/html"
-      - "./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile"
+      - "./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile.d/ddev.caddyfile"
       - "./php:/usr/local/etc/php/ddev.conf.d"
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"

--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -1,63 +1,13 @@
 #ddev-generated
-# This is a copy of the upstream Caddyfile.
+# This is /etc/frankenphp/Caddyfile.d/ddev.caddyfile
+# See the upstream Caddyfile for all customization options
 # https://github.com/php/frankenphp/blob/main/caddy/frankenphp/Caddyfile
-#
-# The Caddyfile is an easy way to configure FrankenPHP and the Caddy web server.
-#
-# https://frankenphp.dev/docs/config
-# https://caddyserver.com/docs/caddyfile
 
-{
-	skip_install_trust
+:8000 {
+    root {$DDEV_DOCROOT}
+    encode zstd br gzip
 
-	{$CADDY_GLOBAL_OPTIONS}
-
-	frankenphp {
-		{$FRANKENPHP_CONFIG}
-	}
+    php_server {
+        #worker /path/to/your/worker.php
+    }
 }
-
-{$CADDY_EXTRA_CONFIG}
-
-{$SERVER_NAME:localhost} {
-	#log {
-	#	# Redact the authorization query parameter that can be set by Mercure
-	#	format filter {
-	#		request>uri query {
-	#			replace authorization REDACTED
-	#		}
-	#	}
-	#}
-
-	root public/
-	encode zstd br gzip
-
-	# Uncomment the following lines to enable Mercure and Vulcain modules
-	#mercure {
-	#	# Transport to use (default to Bolt)
-	#	transport_url {$MERCURE_TRANSPORT_URL:bolt:///data/mercure.db}
-	#	# Publisher JWT key
-	#	publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
-	#	# Subscriber JWT key
-	#	subscriber_jwt {env.MERCURE_SUBSCRIBER_JWT_KEY} {env.MERCURE_SUBSCRIBER_JWT_ALG}
-	#	# Allow anonymous subscribers (double-check that it's what you want)
-	#	anonymous
-	#	# Enable the subscription API (double-check that it's what you want)
-	#	subscriptions
-	#	# Extra directives
-	#	{$MERCURE_EXTRA_DIRECTIVES}
-	#}
-	#vulcain
-
-	{$CADDY_SERVER_EXTRA_DIRECTIVES}
-
-	php_server {
-		#worker /path/to/your/worker.php
-	}
-}
-
-# As an alternative to editing the above site block, you can add your own site
-# block files in the Caddyfile.d directory, and they will be included as long
-# as they use the .caddyfile extension.
-
-import Caddyfile.d/*.caddyfile


### PR DESCRIPTION
## The Issue

- Fixes #3

## How This PR Solves The Issue

Uses `$DDEV_DOCROOT` in `Caddyfile`.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
mkdir -p public
echo "<?php echo 'approot';" >index.php
echo "<?php echo 'public';" >public/index.php
ddev config --docroot=""
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/10/head

ddev restart
# see "approot" in the browser

ddev config --docroot="public"
ddev restart
# see "public" in the browser
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
