### PR TITLE
fix: don't load Xdebug several times, for #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 ## Caveats
 
-- To make Xdebug available on the host, create a `.ddev/docker-compose.frankenphp_extra.yaml` file, and replace `IP_ADDRESS` with the IP from `ddev exec ping -c1 host.docker.internal`. If you're on Linux (including WSL2), use `host-gateway` instead of `IP_ADDRESS`:
+- To make Xdebug available on the host, create a `.ddev/docker-compose.frankenphp_extra.yaml` file:
+  - For Linux and WSL2:
+    ```yaml
+    services:
+      frankenphp:
+        extra_hosts:
+          - "host.docker.internal:host-gateway"
+    ```
+  - For other setups, replace `IP_ADDRESS` with IP from the `ddev exec ping -c1 host.docker.internal` command:
     ```yaml
     services:
       frankenphp:
@@ -56,7 +64,7 @@ ddev stop && ddev debug rebuild -s frankenphp && ddev start
 
 Make sure to commit the `.ddev/.env.frankenphp` file to version control.
 
-To add PHP extensions (see supported extensions [here](https://github.com/mlocati/docker-php-extension-installer?tab=readme-ov-file#supported-php-extensions):
+To add PHP extensions (see supported extensions [here](https://github.com/mlocati/docker-php-extension-installer?tab=readme-ov-file#supported-php-extensions)):
 
 ```bash
 ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="opcache xdebug spx"

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -9,6 +9,8 @@ services:
         FROM $${FRANKENPHP_DOCKER_IMAGE}
         ARG FRANKENPHP_PHP_EXTENSIONS=""
         RUN [ -z "$${FRANKENPHP_PHP_EXTENSIONS}" ] || install-php-extensions $${FRANKENPHP_PHP_EXTENSIONS}
+        # Load Xdebug from /usr/local/etc/php/conf.d/ddev-xdebug.ini instead
+        RUN rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
         ARG FRANKENPHP_USER=ddev
         ARG DDEV_UID
         ARG DDEV_GID

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -75,7 +75,8 @@ health_checks() {
 
   run ddev php --ini
   assert_success
-  assert_output --partial "/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+  assert_output --partial "/usr/local/etc/php/conf.d/ddev-xdebug.ini"
+  refute_output --partial "/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
   assert_output --partial "/usr/local/etc/php/conf.d/docker-php-ext-opcache.ini"
 
   run ddev php -m


### PR DESCRIPTION
## The Issue

- For #11

```
$ ddev php -v                                          
Cannot load Xdebug - it was already loaded
...
```

## How This PR Solves The Issue

Fixes it.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/12/head
ddev stop && ddev debug rebuild -s frankenphp && ddev start
ddev php -v
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
