### PR TITLE
feat: don't install PHP extensions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,7 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 ## Caveats
 
-- To make Xdebug available on the host, create a `.ddev/docker-compose.frankenphp_extra.yaml` file:
-  - For Linux and WSL2:
-    ```yaml
-    services:
-      frankenphp:
-        extra_hosts:
-          - "host.docker.internal:host-gateway"
-    ```
-  - For other setups, replace `IP_ADDRESS` with IP from the `ddev exec ping -c1 host.docker.internal` command:
-    ```yaml
-    services:
-      frankenphp:
-        extra_hosts:
-          - "host.docker.internal:IP_ADDRESS"
-    ```
-- `ddev xdebug` is only designed to work in the `web` container, it won't work here.
+- `ddev xdebug` and `ddev xhprof` are only designed to work in the `web` container, it won't work here.
 - `ddev launch` doesn't work. Open the website URL directly in your browser.
 
 ## Advanced Customization
@@ -67,19 +52,38 @@ Make sure to commit the `.ddev/.env.frankenphp` file to version control.
 To add PHP extensions (see supported extensions [here](https://github.com/mlocati/docker-php-extension-installer?tab=readme-ov-file#supported-php-extensions)):
 
 ```bash
-ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="opcache xdebug spx"
+ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="opcache spx"
 ddev add-on get stasadev/ddev-frankenphp
 ddev stop && ddev debug rebuild -s frankenphp && ddev start
 ```
 
 Make sure to commit the `.ddev/.env.frankenphp` file to version control.
 
+To make Xdebug work for Linux and WSL2:
+
+```bash
+# Add xdebug to PHP extensions
+ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="xdebug"
+printf "services:\n  frankenphp:\n    extra_hosts:\n      - \"host.docker.internal:host-gateway\"\n" > .ddev/docker-compose.frankenphp_extra.yaml
+ddev stop && ddev debug rebuild -s frankenphp && ddev start
+```
+
+To make Xdebug work for other setups:
+
+```bash
+ddev start
+printf "services:\n  frankenphp:\n    extra_hosts:\n      - \"host.docker.internal:$(ddev exec "ping -c1 host.docker.internal | awk -F'[()]' '/PING/{print \$2}'")\"\n" > .ddev/docker-compose.frankenphp_extra.yaml
+# Add xdebug to PHP extensions
+ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="xdebug"
+ddev stop && ddev debug rebuild -s frankenphp && ddev start
+```
+
 All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
 | `FRANKENPHP_DOCKER_IMAGE` | `--frankenphp-docker-image` | `dunglas/frankenphp:php8.3` |
-| `FRANKENPHP_PHP_EXTENSIONS` | `--frankenphp-php-extensions` | `opcache xdebug` |
+| `FRANKENPHP_PHP_EXTENSIONS` | `--frankenphp-php-extensions` | (not set) |
 
 ## Resources:
 

--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -9,8 +9,17 @@ services:
         FROM $${FRANKENPHP_DOCKER_IMAGE}
         ARG FRANKENPHP_PHP_EXTENSIONS=""
         RUN [ -z "$${FRANKENPHP_PHP_EXTENSIONS}" ] || install-php-extensions $${FRANKENPHP_PHP_EXTENSIONS}
-        # Load Xdebug from /usr/local/etc/php/conf.d/ddev-xdebug.ini instead
-        RUN rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+        RUN sh -c 'case "$${FRANKENPHP_PHP_EXTENSIONS}" in *xdebug*) \
+          { \
+            echo "zend_extension=xdebug.so"; \
+            echo "xdebug.client_host=host.docker.internal"; \
+            echo "xdebug.discover_client_host=1"; \
+            echo "xdebug.client_port=9003"; \
+            echo "xdebug.mode=debug,develop"; \
+            echo "xdebug.start_with_request=yes"; \
+            echo "xdebug.max_nesting_level=1000"; \
+          } > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
+        esac'
         ARG FRANKENPHP_USER=ddev
         ARG DDEV_UID
         ARG DDEV_GID
@@ -24,7 +33,7 @@ services:
         USER $${FRANKENPHP_USER}
       args:
         FRANKENPHP_DOCKER_IMAGE: ${FRANKENPHP_DOCKER_IMAGE:-dunglas/frankenphp:php8.3}
-        FRANKENPHP_PHP_EXTENSIONS: ${FRANKENPHP_PHP_EXTENSIONS:-opcache xdebug}
+        FRANKENPHP_PHP_EXTENSIONS: ${FRANKENPHP_PHP_EXTENSIONS:-}
         DDEV_UID: ${DDEV_UID}
         DDEV_GID: ${DDEV_GID}
     labels:
@@ -36,6 +45,7 @@ services:
       - VIRTUAL_HOST=${DDEV_HOSTNAME}
       - HTTP_EXPOSE=80:8000
       - HTTPS_EXPOSE=443:8000
+      - PHP_IDE_CONFIG=serverName=${DDEV_SITENAME}.${DDEV_TLD}
     working_dir: /var/www/html
     volumes:
       - "../:/var/www/html"
@@ -46,18 +56,3 @@ services:
     # Two lines below are for Xdebug on Linux, see README.md for details
     # extra_hosts:
     #   - "host.docker.internal:host-gateway"
-    configs:
-      - source: ddev-xdebug.ini
-        target: /usr/local/etc/php/conf.d/ddev-xdebug.ini
-        mode: "0444"
-
-configs:
-  ddev-xdebug.ini:
-    content: |
-      zend_extension=xdebug.so
-      xdebug.client_host=host.docker.internal
-      xdebug.discover_client_host=1
-      xdebug.client_port=9003
-      xdebug.mode=debug,develop
-      xdebug.start_with_request=yes
-      xdebug.max_nesting_level=1000


### PR DESCRIPTION
## The Issue

People should install extensions they want. No need to install `opcache` with `xdebug`.

## How This PR Solves The Issue

Adds `xdebug.ini` on demand.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
