### PR TITLE
test: replace opcache (now installed by default) with redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Make sure to commit the `.ddev/.env.frankenphp` file to version control.
 To add PHP extensions (see supported extensions [here](https://github.com/mlocati/docker-php-extension-installer?tab=readme-ov-file#supported-php-extensions)):
 
 ```bash
-ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="opcache spx"
+ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="redis pdo_mysql"
 ddev add-on get stasadev/ddev-frankenphp
 ddev stop && ddev debug rebuild -s frankenphp && ddev start
 ```

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,7 +39,7 @@ setup() {
   run ddev start -y
   assert_success
 
-  export INSTALL_OPCACHE=false
+  export INSTALL_REDIS=false
 }
 
 health_checks() {
@@ -81,10 +81,10 @@ health_checks() {
 
   run ddev php -m
   assert_success
-  if [ "${INSTALL_OPCACHE}" = "true" ]; then
-    assert_output --partial "Zend OPcache"
+  if [ "${INSTALL_REDIS}" = "true" ]; then
+    assert_output --partial "redis"
   else
-    refute_output --partial "Zend OPcache"
+    refute_output --partial "redis"
   fi
 }
 
@@ -121,15 +121,15 @@ teardown() {
   assert_output --partial "The add-on only works with the 'generic' webserver type."
 }
 
-@test "install from directory docroot=public and install opcache" {
+@test "install from directory docroot=public and install redis" {
   set -eu -o pipefail
 
-  export INSTALL_OPCACHE=true
+  export INSTALL_REDIS=true
 
   run ddev config --docroot=public
   assert_success
 
-  run ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="opcache"
+  run ddev dotenv set .ddev/.env.frankenphp --frankenphp-php-extensions="redis"
   assert_success
   assert_file_exist .ddev/.env.frankenphp
 


### PR DESCRIPTION
## The Issue

Tests failed because OP Cache was added by default.
https://github.com/stasadev/ddev-frankenphp/actions/runs/16045829159/job/45276815076#step:2:295

```
# -- output should not contain substring --
# substring (1 lines):
#   Zend OPcache
```

## How This PR Solves The Issue

Checks for redis installation instead.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/16/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
