### PR TITLE
fix: add user the same way as in DDEV core, fixes #22

### DIFF
--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -21,23 +21,23 @@ services:
             echo "xdebug.max_nesting_level=1000"; \
           } > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini; \
         esac'
-        ARG DDEV_USER
-        ARG DDEV_UID
-        ARG DDEV_GID
+        ARG username
+        ARG uid
+        ARG gid
         RUN <<EOF
-          set -eu
-          groupadd -g $${DDEV_GID} $${DDEV_USER}
-          useradd -u $${DDEV_UID} -g $${DDEV_GID} $${DDEV_USER}
+          set -eu -o pipefail
+          getent group tty || groupadd tty
+          (groupadd --gid $$gid "$$username" || groupadd "$$username" || true) && (useradd -G tty -l -m -s "/bin/bash" --gid "$$username" --comment '' --uid $$uid "$$username" || useradd -G tty -l -m -s "/bin/bash" --gid "$$username" --comment '' "$$username" || useradd  -G tty -l -m -s "/bin/bash" --gid "$$gid" --comment '' "$$username" || useradd -G tty -l -m -s "/bin/bash" --comment '' $$username )
           setcap -r /usr/local/bin/frankenphp
-          chown -R $${DDEV_USER}:$${DDEV_USER} /data/caddy /config/caddy
+          chown -R $${username}:$${username} /data/caddy /config/caddy
         EOF
-        USER $${DDEV_USER}
+        USER $${username}
       args:
         FRANKENPHP_DOCKER_IMAGE: ${FRANKENPHP_DOCKER_IMAGE:-dunglas/frankenphp:php8.3}
         FRANKENPHP_PHP_EXTENSIONS: ${FRANKENPHP_PHP_EXTENSIONS:-}
-        DDEV_USER: ${DDEV_USER}
-        DDEV_UID: ${DDEV_UID}
-        DDEV_GID: ${DDEV_GID}
+        username: ${DDEV_USER}
+        uid: ${DDEV_UID}
+        gid: ${DDEV_GID}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}


### PR DESCRIPTION
## The Issue

- Fixes #22

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Using https://github.com/ddev/ddev/blob/4b5686665ba136867e7252cd080e9a31bc3f83d5/pkg/ddevapp/config.go#L1367-L1368 technique to fix failing build.

## Manual Testing Instructions

On MacOS 15.6 + Docker Desktop:

```bash
ddev config --webserver-type=generic
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/24/head
ddev restart

$ ddev exec -s frankenphp 'whoami && id -u && id -g'
testbot
501
1000

$ ddev exec 'whoami && id -u && id -g'
testbot
501
20
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
