### PR TITLE
build: fix errors, always install xdebug, test php8.4, fixes #31, fixes #29

### DIFF
--- a/docker-compose.frankenphp.yaml
+++ b/docker-compose.frankenphp.yaml
@@ -5,38 +5,7 @@ services:
     hostname: ${DDEV_SITENAME}-frankenphp
     image: ${FRANKENPHP_DOCKER_IMAGE:-dunglas/frankenphp:php8.3}-${DDEV_SITENAME}-built
     build:
-      dockerfile_inline: |
-        ARG FRANKENPHP_DOCKER_IMAGE=scratch
-        FROM $${FRANKENPHP_DOCKER_IMAGE}
-        ARG FRANKENPHP_PHP_EXTENSIONS=""
-        RUN [ -z "$${FRANKENPHP_PHP_EXTENSIONS}" ] || install-php-extensions $${FRANKENPHP_PHP_EXTENSIONS}
-        ARG username
-        ARG uid
-        ARG gid
-        RUN <<EOF
-          set -eu -o pipefail
-          getent group tty || groupadd tty
-          (groupadd --gid $$gid "$$username" || groupadd "$$username" || true) && (useradd -G tty -l -m -s "/bin/bash" --gid "$$username" --comment '' --uid $$uid "$$username" || useradd -G tty -l -m -s "/bin/bash" --gid "$$username" --comment '' "$$username" || useradd  -G tty -l -m -s "/bin/bash" --gid "$$gid" --comment '' "$$username" || useradd -G tty -l -m -s "/bin/bash" --comment '' $$username )
-          setcap -r /usr/local/bin/frankenphp
-          chown -R $${username}:$${username} /data/caddy /config/caddy
-        EOF
-        ARG FRANKENPHP_XDEBUG=false
-        RUN <<EOF
-          set -eu -o pipefail
-          if [ "$${FRANKENPHP_XDEBUG}" = "true" ]; then
-            install-php-extensions xdebug
-            {
-              echo "zend_extension=xdebug.so";
-              echo "xdebug.client_host=host.docker.internal";
-              echo "xdebug.discover_client_host=1";
-              echo "xdebug.client_port=9003";
-              echo "xdebug.mode=debug,develop";
-              echo "xdebug.start_with_request=yes";
-              echo "xdebug.max_nesting_level=1000";
-            } > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
-          fi
-        EOF
-        USER $${username}
+      context: frankenphp
       args:
         FRANKENPHP_DOCKER_IMAGE: ${FRANKENPHP_DOCKER_IMAGE:-dunglas/frankenphp:php8.3}
         FRANKENPHP_PHP_EXTENSIONS: ${FRANKENPHP_PHP_EXTENSIONS:-}

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -1,0 +1,40 @@
+#ddev-generated
+ARG FRANKENPHP_DOCKER_IMAGE=scratch
+FROM ${FRANKENPHP_DOCKER_IMAGE}
+
+SHELL ["/bin/bash", "-eu", "-o", "pipefail", "-c"]
+
+# Install PHP extensions provided by user
+# Always install xdebug, but disable it by default
+ARG FRANKENPHP_PHP_EXTENSIONS=""
+RUN install-php-extensions xdebug ${FRANKENPHP_PHP_EXTENSIONS} && rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+# Add a new user and give it ownership of frankenphp related files
+ARG username
+ARG uid
+ARG gid
+RUN <<EOF
+    getent group tty || groupadd tty
+    (groupadd --gid $gid "$username" || groupadd "$username" || true) && (useradd -G tty -l -m -s "/bin/bash" --gid "$username" --comment '' --uid $uid "$username" || useradd -G tty -l -m -s "/bin/bash" --gid "$username" --comment '' "$username" || useradd  -G tty -l -m -s "/bin/bash" --gid "$gid" --comment '' "$username" || useradd -G tty -l -m -s "/bin/bash" --comment '' $username )
+    setcap -r /usr/local/bin/frankenphp
+    chown -R ${username}:${username} /data/caddy /config/caddy
+EOF
+
+# Enable xdebug on demand with custom DDEV config
+ARG FRANKENPHP_XDEBUG=false
+RUN <<EOF
+    if [ "${FRANKENPHP_XDEBUG}" = "true" ]; then
+        {
+            echo "zend_extension=xdebug.so";
+            echo "xdebug.client_host=host.docker.internal";
+            echo "xdebug.discover_client_host=1";
+            echo "xdebug.client_port=9003";
+            echo "xdebug.mode=debug,develop";
+            echo "xdebug.start_with_request=yes";
+            echo "xdebug.max_nesting_level=1000";
+        } > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini;
+    fi
+EOF
+
+# Run FrankenPHP under created user
+USER ${username}

--- a/install.yaml
+++ b/install.yaml
@@ -5,6 +5,7 @@ project_files:
   - commands/frankenphp/php
   - commands/host/xdebug
   - docker-compose.frankenphp.yaml
+  - frankenphp/Dockerfile
 
 pre_install_actions:
   - |

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -42,6 +42,7 @@ setup() {
   export INSTALL_REDIS=false
   export FRANKENPHP_WORKER=false
   export TEST_DDEV_XDEBUG=false
+  export FRANKENPHP_PHP_VERSION="8.3"
 }
 
 health_checks() {
@@ -57,7 +58,7 @@ health_checks() {
   assert_success
   assert_output --partial "HTTP/1.1 200"
   assert_output --partial "Server: Caddy"
-  assert_output --partial "X-Powered-By: PHP/8.3"
+  assert_output --partial "X-Powered-By: PHP/${FRANKENPHP_PHP_VERSION}"
 
   if [[ "${FRANKENPHP_WORKER}" == "true" ]]; then
     assert_output --partial "X-Request-Count"
@@ -71,7 +72,7 @@ health_checks() {
   assert_success
   assert_output --partial "HTTP/1.1 200"
   assert_output --partial "Server: Caddy"
-  assert_output --partial "X-Powered-By: PHP/8.3"
+  assert_output --partial "X-Powered-By: PHP/${FRANKENPHP_PHP_VERSION}"
 
   if [[ "${FRANKENPHP_WORKER}" == "true" ]]; then
     assert_output --partial "X-Request-Count"
@@ -85,7 +86,7 @@ health_checks() {
   assert_success
   assert_output --partial "HTTP/2 200"
   assert_output --partial "server: Caddy"
-  assert_output --partial "x-powered-by: PHP/8.3"
+  assert_output --partial "x-powered-by: PHP/${FRANKENPHP_PHP_VERSION}"
 
   if [[ "${FRANKENPHP_WORKER}" == "true" ]]; then
     assert_output --partial "x-request-count"
@@ -138,7 +139,7 @@ health_checks() {
 
   run ddev php -v
   assert_success
-  assert_output --partial "PHP 8.3"
+  assert_output --partial "PHP ${FRANKENPHP_PHP_VERSION}"
 
   run ddev php --ini
   assert_success
@@ -190,6 +191,26 @@ teardown() {
   run ddev add-on get "${DIR}"
   assert_success
   run ddev xdebug
+  assert_success
+  health_checks
+}
+
+@test "install from directory php8.4" {
+  set -eu -o pipefail
+
+  export FRANKENPHP_PHP_VERSION="8.4"
+
+  cp "${DIR}"/tests/testdata/index-no-worker.php index.php
+  assert_file_exist index.php
+
+  run ddev dotenv set .ddev/.env.frankenphp --frankenphp-docker-image="dunglas/frankenphp:php${FRANKENPHP_PHP_VERSION}"
+  assert_success
+  assert_file_exist .ddev/.env.frankenphp
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
   assert_success
   health_checks
 }


### PR DESCRIPTION
## The Issue

- Fixes #31
- Fixes #29

## How This PR Solves The Issue

- Adds `SHELL ["/bin/bash", "-eu", "-o", "pipefail", "-c"]`
- Moves `dockerfile_inline` to `.ddev/frankenphp/Dockerfile`
- Always installs `xdebug` extension, disabled by default.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev config --webserver-type=generic
ddev add-on get https://github.com/stasadev/ddev-frankenphp/tarball/refs/pull/34/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
